### PR TITLE
Adds primary and secondary blob hosts to output

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -23,9 +23,19 @@ output "primary_blob_endpoint" {
   description = "The endpoint URL for blob storage in the primary location."
 }
 
+output "primary_blob_host" {
+  value       = azurerm_storage_account.sa.primary_blob_host
+  description = "The endpoint host for blob storage in the primary location."
+}
+
 output "secondary_blob_endpoint" {
   value       = azurerm_storage_account.sa.secondary_blob_endpoint
   description = "The endpoint URL for blob storage in the secondary location."
+}
+
+output "secondary_blob_host" {
+  value       = azurerm_storage_account.sa.secondary_blob_host
+  description = "The endpoint host for blob storage in the secondary location."
 }
 
 output "primary_queue_endpoint" {


### PR DESCRIPTION
Adds primary and secondary blob hosts to output from the storage account. These values are required downstream if you are setting up a cdn endpoint.

I only included the blob hosts specifically as I'm not currently aware of other downstream modules which require the host instead of the endpoint as is the case for azurerm_cdn_endpoint resources

I tested the changes by pointing my local code directly at my wilsonnm02 repo release v0.4.0 and confirming the new attributes are available