### PR TITLE
Add private link endpoint

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,10 @@
+data "azurerm_virtual_network" "vnet" {
+  name                = var.private_link.vnet_name
+  resource_group_name = var.resource_group_name
+}
+
+data "azurerm_subnet" "subnet" {
+  name                 = var.private_link.subnet_name
+  virtual_network_name = var.private_link.vnet_name
+  resource_group_name  = var.resource_group_name
+}

--- a/examples/blob_storage/main.tf
+++ b/examples/blob_storage/main.tf
@@ -77,8 +77,9 @@ module "virtual_network" {
 
   subnets = {
     iaas-outbound = {
-      cidrs             = ["10.1.1.0/27"]
-      service_endpoints = ["Microsoft.Storage"]
+      cidrs                                          = ["10.1.1.0/27"]
+      service_endpoints                              = ["Microsoft.Storage"]
+      enforce_private_link_endpoint_network_policies = true
     }
   }
 }
@@ -94,14 +95,6 @@ module "storage_account" {
   account_kind     = "StorageV2"
   replication_type = "LRS"
 
-  access_list = {
-    "my_ip" = chomp(data.http.my_ip.body)
-  }
-
-  service_endpoints = {
-    "iaas-outbound" = module.virtual_network.subnet["iaas-outbound"].id
-  }
-
   blob_cors = {
     test = {
       allowed_headers    = []
@@ -110,5 +103,11 @@ module "storage_account" {
       exposed_headers    = []
       max_age_in_seconds = 5
     }
+  }
+
+  private_link = {
+    subnet_name   = module.virtual_network.subnets["iaas-outbound"].name
+    vnet_name     = module.virtual_network.vnet.name
+    dns_zone_name = "example.blob.storageaccount.privatelink.azure.com"
   }
 }

--- a/examples/file_storage/main.tf
+++ b/examples/file_storage/main.tf
@@ -77,8 +77,9 @@ module "virtual_network" {
 
   subnets = {
     iaas-outbound = {
-      cidrs             = ["10.1.1.0/27"]
-      service_endpoints = ["Microsoft.Storage"]
+      cidrs                                          = ["10.1.1.0/27"]
+      service_endpoints                              = ["Microsoft.Storage"]
+      enforce_private_link_endpoint_network_policies = true
     }
   }
 }
@@ -91,17 +92,15 @@ module "storage_account" {
   names               = module.metadata.names
   tags                = module.metadata.tags
 
-  account_kind             = "FileStorage"
-  replication_type         = "LRS"
-  account_tier             = "Premium"
-  access_tier              = "Hot"
-  enable_large_file_share  = true
+  account_kind            = "FileStorage"
+  replication_type        = "LRS"
+  account_tier            = "Premium"
+  access_tier             = "Hot"
+  enable_large_file_share = true
 
-  access_list = {
-    "my_ip" = chomp(data.http.my_ip.body)
-  }
-
-  service_endpoints = {
-    "iaas-outbound" = module.virtual_network.subnet["iaas-outbound"].id
+  private_link = {
+    subnet_name   = module.virtual_network.subnets["iaas-outbound"].name
+    vnet_name     = module.virtual_network.vnet.name
+    dns_zone_name = "example.file.storageaccount.privatelink.azure.com"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -98,6 +98,24 @@ variable "service_endpoints" {
   default     = {}
 }
 
+#Example Values
+# {
+#  subnet_name = ""
+#  vnet_name = ""
+#  dns_zone_name = ""
+#}
+variable "private_link" {
+  description = "When defined, enables private link endpoint on the ACR"
+  type        = map(string)
+  default     = {}
+}
+
+variable "private_link_subresource_name" {
+  description = "subresource to assign to private link. Defaults to 'file' for fileshare and 'blob' for blobstorage"
+  type        = string
+  default     = ""
+}
+
 variable "traffic_bypass" {
   description = "Specifies whether traffic is bypassed for Logging/Metrics/AzureServices. Valid options are any combination of Logging, Metrics, AzureServices, or None."
   type        = list(string)
@@ -121,3 +139,4 @@ variable "blob_cors" {
   }))
   default = null
 }
+


### PR DESCRIPTION
This PR adds the ability to create a private link endpoint when creating the resource. This is preferred over the service endpoint because the service endpoint is going away and also because it generates yellow level security issues in the security advisor.