### PR TITLE
Enable CORS for StorageV2 SKU and correct logic issue with validate_static_website evaluation

### DIFF
--- a/local.tf
+++ b/local.tf
@@ -4,8 +4,8 @@ locals {
   account_tier           = (var.account_tier == null ? (var.account_kind == "BlockBlobStorage" || var.account_kind == "FileStorage" ? "Premium" : "Standard") : var.account_tier)
   static_website_enabled = (local.validate_static_website) ? [{}] : []
 
-  validate_static_website = ((var.enable_static_website && var.account_kind == "BlockBlobStorage" || var.account_kind == "StorageV2") ?
-  true : file("ERROR: Account kind must be BlockBlobStorage or StorageV2 when enabling static website"))
+  validate_static_website = ( var.enable_static_website ? ((var.account_kind == "BlockBlobStorage" || var.account_kind == "StorageV2") ?
+  true : file("ERROR: Account kind must be BlockBlobStorage or StorageV2 when enabling static website")) : false )
 
   validate_nfsv3 = (!var.nfsv3_enabled || (var.nfsv3_enabled && var.enable_hns) ?
   true : file("ERROR: NFS V3 can only be enabled when Hierarchical Namespaces are enabled"))

--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,7 @@ resource "azurerm_storage_account" "sa" {
   account_tier             = local.account_tier
   account_replication_type = var.replication_type
   access_tier              = var.access_tier
+  tags                     = var.tags
 
   is_hns_enabled           = var.enable_hns
   large_file_share_enabled = var.enable_large_file_share

--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,8 @@ resource "azurerm_storage_account" "sa" {
 
   network_rules {
     default_action             = var.default_network_rule
-    ip_rules                   = values(var.access_list)
+    #ip_rules                   = values(var.access_list)
+    ip_rules                   = (contains(values(var.access_list), "0.0.0.0/0") ? [] : values(var.access_list))
     virtual_network_subnet_ids = values(var.service_endpoints)
     bypass                     = var.traffic_bypass
   }

--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,7 @@ resource "azurerm_storage_account" "sa" {
   }
 
   dynamic "blob_properties" {
-    for_each = (var.account_kind == "BlockBlobStorage" ? [1] : [])
+    for_each = ((var.account_kind == "BlockBlobStorage" || var.account_kind == "StorageV2") ? [1] : [])
     content {
       dynamic "delete_retention_policy" {
         for_each = (var.blob_delete_retention_days == null ? [] : [1])

--- a/main.tf
+++ b/main.tf
@@ -58,8 +58,7 @@ resource "azurerm_storage_account" "sa" {
 
   network_rules {
     default_action             = var.default_network_rule
-    #ip_rules                   = values(var.access_list)
-    ip_rules                   = (contains(values(var.access_list), "0.0.0.0/0") ? [] : values(var.access_list))
+    ip_rules                   = values(var.access_list)
     virtual_network_subnet_ids = values(var.service_endpoints)
     bypass                     = var.traffic_bypass
   }

--- a/output.tf
+++ b/output.tf
@@ -23,9 +23,19 @@ output "primary_blob_endpoint" {
   description = "The endpoint URL for blob storage in the primary location."
 }
 
+output "primary_blob_host" {
+  value       = azurerm_storage_account.sa.primary_blob_host
+  description = "The endpoint host for blob storage in the primary location."
+}
+
 output "secondary_blob_endpoint" {
   value       = azurerm_storage_account.sa.secondary_blob_endpoint
   description = "The endpoint URL for blob storage in the secondary location."
+}
+
+output "secondary_blob_host" {
+  value       = azurerm_storage_account.sa.secondary_blob_host
+  description = "The endpoint host for blob storage in the secondary location."
 }
 
 output "primary_queue_endpoint" {


### PR DESCRIPTION
Enables the application of CORS policies to storage_accounts which use the StorageV2 SKU.

Corrects a logic issue with validate_static_website evaluation which currently forces enable_static_website to be true or terraform will hard-error