### PR TITLE
Adds primary_web_host/secondary_web_host to outputs

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -86,9 +86,19 @@ output "secondary_dfs_endpoint" {
   description = "The endpoint URL for DFS storage in the secondary location."
 }
 
+output "primary_web_host" {
+  value       = azurerm_storage_account.sa.primary_web_host
+  description = "Hostname with port for web storage in the primary location."
+}
+
 output "primary_web_endpoint" {
   value       = azurerm_storage_account.sa.primary_web_endpoint
   description = "The endpoint URL for web storage in the primary location."
+}
+
+output "secondary_web_host" {
+  value       = azurerm_storage_account.sa.secondary_web_host
+  description = "Hostname with port for web storage in the secondary location."
 }
 
 output "secondary_web_endpoint" {


### PR DESCRIPTION
The attributes are required when binding a storage account to a CDN profile that has been enabled to serve a static website, In this configuration the azurerm_cdn_endpoint resource requires both the `origin_host_header` and `origin.host_name` arguments to use `primary_web_host` or `secondary_web_host`. These are not interchangeable with `primary_web_endpoint` and `secondary_web_endpoint`, as both are FQDNs with protocol prefixes (e.g., "https://...").