### PR TITLE
Add cross-tenant replication variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,7 @@ resource "azurerm_storage_account" "sa" {
   infrastructure_encryption_enabled = var.infrastructure_encryption_enabled
   shared_access_key_enabled         = var.shared_access_key_enabled
   default_to_oauth_authentication   = var.default_to_oauth_authentication
+  cross_tenant_replication_enabled  = var.cross_tenant_replication_enabled
 
   identity {
     type = "SystemAssigned"
@@ -32,7 +33,7 @@ resource "azurerm_storage_account" "sa" {
   dynamic "blob_properties" {
     for_each = ((var.account_kind == "BlockBlobStorage" || var.account_kind == "StorageV2") ? [1] : [])
     content {
-      versioning_enabled = var.blob_versioning_enabled
+      versioning_enabled       = var.blob_versioning_enabled
       last_access_time_enabled = var.blob_last_access_time_enabled
 
       dynamic "delete_retention_policy" {
@@ -41,14 +42,14 @@ resource "azurerm_storage_account" "sa" {
           days = var.blob_delete_retention_days
         }
       }
-      
+
       dynamic "container_delete_retention_policy" {
         for_each = (var.container_delete_retention_days == 0 ? [] : [1])
         content {
           days = var.container_delete_retention_days
         }
       }
-      
+
       dynamic "cors_rule" {
         for_each = (var.blob_cors == null ? {} : var.blob_cors)
         content {

--- a/variables.tf
+++ b/variables.tf
@@ -201,3 +201,9 @@ variable "container_delete_retention_days" {
   type        = number
   default     = 7
 }
+
+variable "cross_tenant_replication_enabled" {
+  description = "Controls whether cross-tenant replication is allowed."
+  type        = bool
+  default     = true
+}

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.0"
+      version = "~> 3.5"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
Storage accounts with cross-tenant replication enabled now violate policy storage-storageaccounts-crossTenantReplication.  Having this functionality enabled was the Azure default until December 15 2023, and is still the default in the azurerm provider (up through at least version 3.109.0).  We need a way to toggle this off.

Summary of module changes:
1. variables.tf - add new "cross_tenant_replication_enabled" variable to toggle the related functionality
2. main.tf - reference the new variable in the resource implementation
3. versions.tf - somewhat-symbolically bump up the azurerm version since this capability was added in azurerm 3.5.0 (which I suspect most people using this module are well beyond)
4. Ran terraform fmt

References:
1. Azure default until Dec 15 2023: https://learn.microsoft.com/en-us/azure/storage/blobs/object-replication-prevent-cross-tenant-policies?tabs=portal#remediate-cross-tenant-object-replication
2. Still the azurerm default: https://registry.terraform.io/providers/hashicorp/azurerm/3.109.0/docs/resources/storage_account
3. Request for azurerm to match the new Azure default: https://github.com/hashicorp/terraform-provider-azurerm/issues/26127