### PR TITLE
Add allowed_copy_scope to azurerm_storage_account resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ resource "azurerm_storage_account" "sa" {
   shared_access_key_enabled         = var.shared_access_key_enabled
   public_network_access_enabled     = var.public_network_access_enabled
   default_to_oauth_authentication   = var.default_to_oauth_authentication
-  allowed_copy_scope                = "AAD"
+  allowed_copy_scope = var.allowed_copy_scope != null ? var.allowed_copy_scope : null
   identity {
     type = "SystemAssigned"
   }

--- a/main.tf
+++ b/main.tf
@@ -26,6 +26,7 @@ resource "azurerm_storage_account" "sa" {
   shared_access_key_enabled         = var.shared_access_key_enabled
   public_network_access_enabled     = var.public_network_access_enabled
   default_to_oauth_authentication   = var.default_to_oauth_authentication
+  allowed_copy_scope                = "AAD"
   identity {
     type = "SystemAssigned"
   }

--- a/variables.tf
+++ b/variables.tf
@@ -212,3 +212,9 @@ variable "container_delete_retention_days" {
   type        = number
   default     = 7
 }
+
+variable "allowed_copy_scope" {
+  description = "Restrict copy to and from Storage Accounts within an AAD tenant or with Private Links to the same VNet. Possible values are AAD and PrivateLink."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
This pull request adds the `allowed_copy_scope` property to the `azurerm_storage_account` resource. The `allowed_copy_scope` property allows for restricting copy operations to and from Storage Accounts within an AAD tenant or with Private Links to the same VNet. The default value is `null`, but it can be set to either "AAD" or "PrivateLink".