### PR TITLE
default public_network_access_enabled = true

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -80,6 +80,7 @@ variable "https_traffic_only_enabled" {
 variable "public_network_access_enabled" {
   description = "Allow or disallow public access to all blobs or containers in the storage account. The default interpretation is true for this property."
   type        = bool
+  default     = true
 }
 
 variable "min_tls_version" {


### PR DESCRIPTION
variable "public_network_access_enabled" in the description it says the default interpretation is true:
"Allow or disallow public access to all blobs or containers in the storage account. The default interpretation is true for this property."

Adding default = true