### PR TITLE
Added Storage Queues Config. 

### DIFF
--- a/examples/storage_queue/main.tf
+++ b/examples/storage_queue/main.tf
@@ -1,0 +1,94 @@
+provider "azurerm" {
+  features {}
+  storage_use_azuread = true
+}
+
+data "http" "my_ip" {
+  url = "https://ifconfig.me"
+}
+
+data "azurerm_subscription" "current" {
+}
+
+resource "random_string" "random" {
+  length  = 12
+  upper   = false
+  special = false
+}
+
+module "subscription" {
+  source          = "github.com/Azure-Terraform/terraform-azurerm-subscription-data.git?ref=v1.0.0"
+  subscription_id = data.azurerm_subscription.current.subscription_id
+}
+
+module "naming" {
+  source = "git@github.com:Azure-Terraform/example-naming-template.git?ref=v1.0.0"
+}
+
+module "metadata" {
+  source = "github.com/Azure-Terraform/terraform-azurerm-metadata.git?ref=v1.1.0"
+
+  naming_rules = module.naming.yaml
+
+  market              = "us"
+  project             = "https://github.com/Azure-Terraform/terraform-azurerm-storage-account/tree/main/example"
+  location            = "eastus2"
+  environment         = "sandbox"
+  product_name        = random_string.random.result
+  business_unit       = "infra"
+  product_group       = "contoso"
+  subscription_id     = module.subscription.output.subscription_id
+  subscription_type   = "dev"
+  resource_group_type = "app"
+}
+
+module "resource_group" {
+  source = "github.com/Azure-Terraform/terraform-azurerm-resource-group.git?ref=v1.0.0"
+
+  location = module.metadata.location
+  names    = module.metadata.names
+  tags     = module.metadata.tags
+}
+
+module "virtual_network" {
+  source = "github.com/Azure-Terraform/terraform-azurerm-virtual-network.git?ref=v5.0.0"
+
+  naming_rules = module.naming.yaml
+
+  resource_group_name = module.resource_group.name
+  location            = module.resource_group.location
+  names               = module.metadata.names
+  tags                = module.metadata.tags
+
+  address_space = ["10.1.1.0/24"]
+
+  subnets = {
+    iaas-outbound = {
+      cidrs             = ["10.1.1.0/27"]
+      service_endpoints = ["Microsoft.Storage"]
+    }
+  }
+}
+
+module "storage_account" {
+  source = "../../"
+
+  resource_group_name = module.resource_group.name
+  location            = module.resource_group.location
+  tags                = module.metadata.tags
+
+  public_network_access_enabled = false
+  replication_type              = "LRS"
+  enable_large_file_share       = true
+
+  access_list = {
+    "my_ip" = data.http.my_ip.body
+  }
+
+  service_endpoints = {
+    "iaas-outbound" = module.virtual_network.subnet["iaas-outbound"].id
+  }
+
+  queue_names = ["ins-queue-name", "ins-queue-name-2"]
+
+}

--- a/main.tf
+++ b/main.tf
@@ -89,7 +89,6 @@ resource "azurerm_storage_encryption_scope" "scope" {
   infrastructure_encryption_required = coalesce(each.value.enable_infrastructure_encryption, var.infrastructure_encryption_enabled)
 }
 
-
 resource "azurerm_role_assignment" "smb_contributor" {
   for_each = toset(var.smb_contributors)
 

--- a/main.tf
+++ b/main.tf
@@ -89,14 +89,7 @@ resource "azurerm_storage_encryption_scope" "scope" {
   infrastructure_encryption_required = coalesce(each.value.enable_infrastructure_encryption, var.infrastructure_encryption_enabled)
 }
 
-resource "azurerm_storage_queue" "queues" {
-  for_each = var.queue_names != [] ? toset(var.queue_names) : []
 
-  name               = each.key
-  storage_account_id = azurerm_storage_account.sa.id
-  metadata           = lookup(var.queue_metadata_map, each.key, {})
-
-}
 resource "azurerm_role_assignment" "smb_contributor" {
   for_each = toset(var.smb_contributors)
 
@@ -153,4 +146,13 @@ resource "azurerm_storage_share_file" "sf" {
   content_type     = each.value.content_type
   content_md5      = filemd5(each.value.local_path)
   depends_on       = [azurerm_storage_account.sa, azurerm_storage_share.ss]
+}
+
+resource "azurerm_storage_queue" "queues" {
+  for_each = var.queue_names != [] ? toset(var.queue_names) : []
+
+  name               = each.key
+  storage_account_id = azurerm_storage_account.sa.id
+  metadata           = lookup(var.queue_metadata_map, each.key, {})
+
 }

--- a/main.tf
+++ b/main.tf
@@ -89,6 +89,14 @@ resource "azurerm_storage_encryption_scope" "scope" {
   infrastructure_encryption_required = coalesce(each.value.enable_infrastructure_encryption, var.infrastructure_encryption_enabled)
 }
 
+resource "azurerm_storage_queue" "queues" {
+  for_each = var.queue_names != [] ? toset(var.queue_names) : []
+
+  name               = each.key
+  storage_account_id = azurerm_storage_account.sa.id
+  metadata           = lookup(var.queue_metadata_map, each.key, {})
+
+}
 resource "azurerm_role_assignment" "smb_contributor" {
   for_each = toset(var.smb_contributors)
 

--- a/output.tf
+++ b/output.tf
@@ -147,6 +147,11 @@ output "encryption_scope_ids" {
   }
 }
 
+output "queue_urls" {
+  value = {
+    for name, q in azurerm_storage_queue.queues : name => q.id
+  }
+}
 output "storage_shares" {
   description = "List of storage shares object."
   value       = azurerm_storage_share.ss

--- a/output.tf
+++ b/output.tf
@@ -147,12 +147,13 @@ output "encryption_scope_ids" {
   }
 }
 
+output "storage_shares" {
+  description = "List of storage shares object."
+  value       = azurerm_storage_share.ss
+}
+
 output "queue_urls" {
   value = {
     for name, q in azurerm_storage_queue.queues : name => q.id
   }
-}
-output "storage_shares" {
-  description = "List of storage shares object."
-  value       = azurerm_storage_share.ss
 }

--- a/variables.tf
+++ b/variables.tf
@@ -214,6 +214,17 @@ variable "container_delete_retention_days" {
   default     = 7
 }
 
+variable "queue_names" {
+  type        = list(string)
+  default     = []
+  description = "List of queue names to create. If empty, no queues will be created."
+}
+
+variable "queue_metadata_map" {
+  type = map(map(string))
+  default = {}
+  description = "Map of queue name to its metadata map"
+}
 variable "allowed_copy_scope" {
   description = "Restrict copy to and from Storage Accounts within an AAD tenant or with Private Links to the same VNet. Possible values are AAD and PrivateLink."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -214,17 +214,6 @@ variable "container_delete_retention_days" {
   default     = 7
 }
 
-variable "queue_names" {
-  type        = list(string)
-  default     = []
-  description = "List of queue names to create. If empty, no queues will be created."
-}
-
-variable "queue_metadata_map" {
-  type = map(map(string))
-  default = {}
-  description = "Map of queue name to its metadata map"
-}
 variable "allowed_copy_scope" {
   description = "Restrict copy to and from Storage Accounts within an AAD tenant or with Private Links to the same VNet. Possible values are AAD and PrivateLink."
   type        = string
@@ -267,4 +256,16 @@ variable "storage_shares" {
   }))
   default  = []
   nullable = false
+}
+
+variable "queue_names" {
+  type        = list(string)
+  default     = []
+  description = "List of queue names to create. If empty, no queues will be created."
+}
+
+variable "queue_metadata_map" {
+  type = map(map(string))
+  default = {}
+  description = "Map of queue name to its metadata map"
 }


### PR DESCRIPTION
# Storage Queues. 

Added Storage queue config from. 
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue

## Testing: 

Deployed and tested Queues into iqct-emm subscription. 

---

This pull request adds support for Azure Storage Queues to the Terraform module, allowing users to provision storage queues alongside storage accounts and shares. The changes introduce new variables for queue configuration, update the resource definitions to create queues, and expose queue information as outputs. An example configuration is also provided to demonstrate usage.

**Azure Storage Queue Support**

* Added the `azurerm_storage_queue` resource to `main.tf`, enabling creation of storage queues based on the new `queue_names` variable and allowing custom metadata per queue via `queue_metadata_map`.
* Introduced new variables in `variables.tf`: `queue_names` (list of queue names to create) and `queue_metadata_map` (map of queue name to its metadata), making queue creation configurable.

**Outputs**

* Added a new output `queue_urls` in `output.tf` to expose the IDs of created storage queues, keyed by queue name.

**Example Usage**

* Provided a comprehensive example in `examples/storage_queue/main.tf` showing how to use the new queue functionality, including metadata, naming, networking, and access configuration.